### PR TITLE
fix #6

### DIFF
--- a/Fine_Tuning_BERT_for_Spam_Classification.ipynb
+++ b/Fine_Tuning_BERT_for_Spam_Classification.ipynb
@@ -1431,7 +1431,7 @@
         "    def forward(self, sent_id, mask):\n",
         "\n",
         "      #pass the inputs to the model  \n",
-        "      _, cls_hs = self.bert(sent_id, attention_mask=mask)\n",
+        "      _, cls_hs = self.bert(sent_id, attention_mask=mask).values()\n",
         "      \n",
         "      x = self.fc1(cls_hs)\n",
         "\n",
@@ -2028,9 +2028,7 @@
         "colab_type": "code",
         "colab": {}
       },
-      "source": [
-        ""
-      ],
+      "source": [],
       "execution_count": null,
       "outputs": []
     }


### PR DESCRIPTION
I got ' 'str' object has no attribute 'dim'' by simply running the notebook. I figured it out by looking at [this](https://stackoverflow.com/questions/64901831/huggingface-transformer-model-returns-string-instead-of-logits). It seems either specifying 'return_dict=False' or calling 'values()' method could force the bert model to return a tuple. Hope this helps.

