### PR TITLE
Update Fine_Tuning_BERT_for_Spam_Classification.ipynb

### DIFF
--- a/Fine_Tuning_BERT_for_Spam_Classification.ipynb
+++ b/Fine_Tuning_BERT_for_Spam_Classification.ipynb
@@ -1053,7 +1053,7 @@
       },
       "source": [
         "# import BERT-base pretrained model\n",
-        "bert = AutoModel.from_pretrained('bert-base-uncased')\n",
+        "bert = AutoModel.from_pretrained('bert-base-uncased', return_dict=False)\n",
         "\n",
         "# Load the BERT tokenizer\n",
         "tokenizer = BertTokenizerFast.from_pretrained('bert-base-uncased')"


### PR DESCRIPTION
Fix based on https://stackoverflow.com/questions/65132144/bertmodel-transformers-outputs-string-instead-of-tensor
Since one of the 3.X releases of the transformers library, the models do not return tuples anymore but specific output objects: